### PR TITLE
 angemeldete Person durch teilnehmede Person ersetzen

### DIFF
--- a/go.rst
+++ b/go.rst
@@ -172,10 +172,10 @@ Wahl stehen.
    Adressaten haben müssen, Positionspapiere, die keinen Adressaten haben,
    sowie ZaPF-interne Selbstverpflichtungen und Aufträge an den StAPF.
 
-3. Stimmberechtigt für Meinungsbilder ist jede angemeldete Person der ZaPF.
+3. Stimmberechtigt für Meinungsbilder ist jede teilnehmende Person der ZaPF.
 
 4. Stimmberechtigt für Abstimmungen ist jede im Plenum anwesende Fachschaft
-   die mindestens eine angemeldete Person hat.
+   die mindestens eine teilnehmende Person hat.
    Jede Fachschaft hat eine Stimme; wie sie abstimmt, ist innerhalb der
    jeweiligen Fachschaft zu regeln.
    Den Fachschaften ist Zeit zur Beratung zu gewähren.
@@ -235,7 +235,7 @@ Wahl stehen.
    Vertrauenspersonen im Anfangsplenum unterschieden.
 
 4. Stimmberechtigt für normale Personenwahlen ist jede im Plenum anwesende
-   Fachschaft die mindestens eine angemeldete Person hat.
+   Fachschaft die mindestens eine teilnehmende Person hat.
    Jede Fachschaft hat eine Stimme; wie sie abstimmt, ist innerhalb der
    jeweiligen Fachschaft zu regeln.
    Den Fachschaften ist Zeit zur Beratung zu gewähren.


### PR DESCRIPTION
Da "angemeldete Person" die ausrichtende Fachschaft ausschließt, sollte dieser
Begriff durch "teilnehmende Person" ersetzt werden. Dies ist bisher nicht für
die Vertrauenspersonen ersetzt, da die Frage, ob Mitglieder der ausrichtenden
Fachschaft Teil des gewählten Teils der Vertrauenspersonen sein dürfen,
gesondert geführt werden sollte.
