### PR TITLE
Bedingungen für die Abwahl von Personen eingefügt

### DIFF
--- a/go.rst
+++ b/go.rst
@@ -306,7 +306,7 @@ Wahl stehen.
      besetzt. Bei Gleichstand entscheidet das Los.
 
 9. Abwahlen sind auch bei Abwesenheit der betroffenen Person möglich und
-   bedürfen einer Zweidrittelmehrheit. Der Antrag auf Abwahl ist bis spätestnes
+   bedürfen einer Zweidrittelmehrheit. Der Antrag auf Abwahl ist bis spätestens
    15 Uhr am Vortag der ausrichtenden Fachschaft anzukündigen.
    Die betroffene Person ist jedoch nach Möglichkeit anzuhören.
 

--- a/go.rst
+++ b/go.rst
@@ -306,7 +306,8 @@ Wahl stehen.
      besetzt. Bei Gleichstand entscheidet das Los.
 
 9. Abwahlen sind auch bei Abwesenheit der betroffenen Person möglich und
-   bedürfen einer Zweidrittelmehrheit.
+   bedürfen einer Zweidrittelmehrheit. Der Antrag auf Abwahl ist bis spätestnes
+   15 Uhr am Vortag der ausrichtenden Fachschaft anzukündigen.
    Die betroffene Person ist jedoch nach Möglichkeit anzuhören.
 
 Anhang: Versionshistorie


### PR DESCRIPTION
Dies ist keine Neuerung, sondern stammt aus der Satzung. Da dies aber das
Verfahren der Abwahl regelt, ist es in der Geschäftsordnung besser aufgehoben.
