### PR TITLE
Anpassung der Mindestzahl an Ja-Stimmen an die aktuelle Realität

### DIFF
--- a/go.rst
+++ b/go.rst
@@ -146,7 +146,7 @@ Mitglieder und Helferinnen und Helfer der ausführenden Fachschaft.
 
 Dieser Abschnitt regelt die Abstimmungen und Meinungsbilder des ZaPF-Plenums
 sowie die Wahlmodi für Personenwahlen. Die Beschlussfähigkeit für Abstimmungen
-und Personenwahlen ist gegeben, wenn *fünfzehn Physikfachschaften*
+und Personenwahlen ist gegeben, wenn *zwanzig Physikfachschaften*
 im Plenum anwesend sind.
 
 Die Beschlussfähigkeit ist ausschließlich für Abstimmungen und Personenwahlen
@@ -247,7 +247,7 @@ Wahl stehen.
    und Kandidaten zu diskutieren.
    Diese Diskussion wird nicht protokolliert.
    Ein Kandidat oder eine Kandidatin gilt als gewählt, wenn er oder sie mehr
-   Ja-Stimmen als Nein-Stimmen, *mindestens acht Ja-Stimmen*
+   Ja-Stimmen als Nein-Stimmen, *mindestens elf Ja-Stimmen*
    erhält und die Wahl annimmt.
    Enthaltungen sind möglich und wirken wie nicht oder ungültig abgegebene
    Stimmen.
@@ -369,7 +369,7 @@ angenommen werden.
 Formale Gegenrede bedeutet nur bekanntzugeben, dass man dagegen ist, inhaltliche
 Gegenrede beinhaltet eine Begründung.
 
-Beschlussfähigkeit bei fünfzehn anwesenden Fachschaften
+Beschlussfähigkeit bei zwanzig anwesenden Fachschaften
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Dies entspricht nach unserem Kenntnisstand etwa einem Viertel der Physikfachschaften.
@@ -377,6 +377,6 @@ Dies entspricht nach unserem Kenntnisstand etwa einem Viertel der Physikfachscha
 Mindestanzahl von Ja-Stimmen bei Personenzahlen
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Das Minimum von acht Ja-Stimmen bewirkt, dass Kandidatinnen und Kandidaten
+Das Minimum von elf Ja-Stimmen bewirkt, dass Kandidatinnen und Kandidaten
 mindestens die absolute Mehrheit der zur Beschlussfähigkeit notwendigen Stimmen
 erhalten muss.


### PR DESCRIPTION
Aktuell werden über 80 Fachschaften zur ZaPF eingeladen, die Mindestzahl von 15 Fachschaften für die Beschlussfähigkeit ist damit nicht mehr die aktuelle Realität.