### PR TITLE
Inklusivere Formulierung für die Wahl der Vertrauenspersonen

### DIFF
--- a/go.rst
+++ b/go.rst
@@ -257,10 +257,10 @@ Wahl stehen.
    Verfügung stehen, werden sie nach Anzahl der Ja-Stimmen besetzt.
 
 6. Im Anfangsplenum werden sechs Vertrauenspersonen gewählt. Zur Wahl
-   berechtigt sind alle angemeldeten Teilnehmer der ZaPF.
+   berechtigt sind alle anwesenden natürlichen Personen.
 
 7. Die Wahl der Vertrauenspersonen erfolgt per Wahl durch
-   Zustimmung aus einem Pool von angemeldeten Teilnehmern der ZaPF.
+   Zustimmung aus einem Pool von teilnehmenden Personen der ZaPF.
    Bewerbungen hierfür müssen bis spätestens zu Beginn des Anfangsplenums
    in schriftlicher Form an eine, bis spätestens zwei Wochen vor Beginn der
    ZaPF durch die ausführende Fachschaft bekanntzugebende, Adresse erfolgen.


### PR DESCRIPTION
Diese PR löst das Problem, dass die seltsame Formulierung "angemeldete Teilnehmer" nicht sinnvoll vereinbar mit "teilnehmenden Personen" und der ursprünglichen Intention, dass jeder im Plenum Anwesende durch Vertrauenspersonen repräsentiert sein sollte.