### PR TITLE
Diffs für GO- und Satzungsänderungen hinzugefügt.

### DIFF
--- a/go.rst
+++ b/go.rst
@@ -94,7 +94,7 @@ Mitglieder und Helferinnen und Helfer der ausführenden Fachschaft.
    Die Vertreterin oder der Vertreter ist dann die neue antragstellende Person.
 
 5. Anträge, die bestehende Aussagen der ZaPF, insbesondere die Geschäftsordnung
-   und die Satzung, ändern wollen, müssen ihre Änderung des bestehenden Textes
+   und die Satzung, ändern wollen, sollen ihre Änderung des bestehenden Textes
    *geeignet nachvollziehbar* machen.
    Diese Pflicht entfällt für Initiativanträge.
 

--- a/go.rst
+++ b/go.rst
@@ -93,6 +93,12 @@ Mitglieder und Helferinnen und Helfer der ausführenden Fachschaft.
    der Sitzungsleitung mitteilen.
    Die Vertreterin oder der Vertreter ist dann die neue antragstellende Person.
 
+5. Anträge, die bestehende Aussagen der ZaPF, insbesondere die Geschäftsordnung
+   und die Satzung, ändern wollen, müssen ihre Änderung des bestehenden Textes
+   *geeignet nachvollziehbar* machen.
+   Diese Pflicht entfällt für Initiativanträge.
+
+
 3.2 Geschäftsordnungsanträge
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -383,3 +389,10 @@ Mindestanzahl von Ja-Stimmen bei Personenzahlen
 Das Minimum von acht Ja-Stimmen bewirkt, dass Kandidatinnen und Kandidaten
 mindestens die absolute Mehrheit der zur Beschlussfähigkeit notwendigen Stimmen
 erhalten muss.
+
+Geeignete Form des Nachvollziehbarmachens
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Es kann sehr schwer sein kleinste Änderungen in Texten nachzuvollziehen, es
+erleichtert die Arbeit im Plenum deswegen erheblich, wenn Änderungen bestehender
+Texte im einzelnen hervorgehoben sind. Dies kann z.B. durch ein Diff geschehen.


### PR DESCRIPTION
Diese PR soll einen Absatz hinzufügen um Änderungen bestehender Resolutionen und anderer Ergebnisse der ZaPF einfacher lesbarer zu machen.