### PR TITLE
GO-Antrag auf Nichtbefassung soll nicht geheim abgestimmt werden

### DIFF
--- a/go.rst
+++ b/go.rst
@@ -130,7 +130,7 @@ Mitglieder und Helferinnen und Helfer der ausführenden Fachschaft.
    - zur Schließung der Redeliste und Verweisung in eine Arbeitsgruppe mit
      Recht auf ein Meinungsbild im Plenum (auch bekannt als "Vertagung auf das
      nächste Plenum bzw. die nächste ZaPF") *
-   - Nichtbefassung *
+   - Nichtbefassung (kann nicht geheim abgestimmt werden) *
    - geheime Abstimmung (ohne Gegenrede, ohne Abstimmung, setzt namentliche
      Abstimmung und Abstimmung per Handzeichen außer Kraft)
    - Neuwahl der Sitzungsleitung unter Benennung eines oder mehrerer Gegenkandidaten


### PR DESCRIPTION
Dieser PR ändert den GO-Antrag auf Nichtbefassung so, dass er nicht geheim abgestimmt werden kann. Dies soll Fachschaften entsprechend der Satzungsänderung https://github.com/ZaPF/Satzung_der_ZaPF/pull/20 ermöglichen zu signailiseren, dass sie sich mit einem Thema nicht befasst haben