### PR TITLE
Redaktionelle Anpassung

### DIFF
--- a/go.rst
+++ b/go.rst
@@ -147,7 +147,7 @@ Mitglieder und helfende Personen der ausführenden Fachschaft.
    - geheime Abstimmung (ohne Gegenrede, ohne Abstimmung, setzt namentliche
      Abstimmung und Abstimmung per Handzeichen außer Kraft)
    - Neuwahl der Sitzungsleitung unter Benennung eines oder mehrerer Gegenkandidierender
-   - Neuwahl des Protokollanten unter Benennung eines oder mehrerer Gegenkandidierender
+   - Neuwahl der Protokollführung unter Benennung eines oder mehrerer Gegenkandidierender
    - Einholung eines Meinungsbildes im Plenum
    - Verfahrensvorschlag
    - namentliche Abstimmung (ohne Gegenrede, ohne Abstimmung, setzt Abstimmung


### PR DESCRIPTION
Bei der Letzten Änderung wurde diese Stelle übersehen und wird jetzt konsistent zu https://github.com/ZaPF/Geschaeftsordnung_ZaPF/commit/0f66478b18eb0c147a40b6cd35fc7d6930110778 redaktionell angepasst.