### PR TITLE
Erweitere die Antragsfrist für GO-Änderungen

### DIFF
--- a/go.md
+++ b/go.md
@@ -73,6 +73,9 @@ Mitglieder und helfende Personen der ausrichtenden Fachschaft.
    Zur Abstimmung im Zwischen- oder Abschlussplenum müssen Anträge zur Änderung
    der Geschäftsordnung spätestens um 15:00 Uhr am Tag vor dem Zwischen- oder
    Abschlussplenum bekanntgegeben werden.
+   Im Fall mehrtägiger Plenen muss ein Änderungsantrag, zur Abstimmung nicht früher als
+   am Folgetag, bis 15:00 am Tag vor dem letzten konsekutiven Plenumstag, ab Beginn des
+   Plenums, bekanntgegeben werden.
    Änderungen dieser Geschäftsordnung sind nicht durch Initiativanträge möglich.
    Die Änderung der Geschäftsordnung tritt automatisch zum nächsten Plenum in Kraft.
 5. Anträge zur Änderung des Verhaltenskodex der ZaPF zur Abstimmung im Anfangsplenum


### PR DESCRIPTION
In der jüngeren Vergangenheit sind ausrichtende Fachschaften dazu übergegangen mehrtätige Endplenen zu veranstalten. Die Abgabefrist für GO-Änderungen fällt dabei im schlimsten Fall auf den ersten vollständigen Tag der ZaPF und erlaubt nur wenige Arbeitskreise stattfinden zu lassen.

Die Intention der Frist war Fachschaften ausreichende Zeit zu geben sich mit den Änderungsanträgen zu befassen. Dies ist auch gewährleistet, so lange sichergestellt wird, dass am letzten Plenumstag mit "etwa einem" Tag Vorlauf darüber abgestimmt wird.

Dies verkürzt die Zeit zur Meinungsbildung nicht, da die Anküdigungsfrist und die Pflicht einen Arbeitskreis zum Thema abzuhalten, unberührt bleibt.

Die Formulierung "letzter konsekutiver Endplenumstag ab Beginn des Endplenums" zielt darauf ab, dass während der Pandemie das Endplenum für Briefwahl unterbrochen wurde, so dass der letzte Endplenumstag Wochen nach Beginn des Endplenums war. In diesem Fall muss die Antragsfrist relativ zum Ende des ersten Endplenumsblocks sein, z.B. sei die letzte Frist bei einem fünftägigen Endplenum: Tag 1, Tag 2, Tag 3, Unterbrechung, Tag 4, Tag 5 um 15 Uhr an Tag 2, zur Abstimmung an Tag 3 und jeweils um 15 Uhr an Tag 1 und Tag 0 zur Abstimmung an Tag 2 und Tag 1 respektive.

Dies ist analog zu https://github.com/ZaPF/Satzung_der_ZaPF/pull/38.