### PR TITLE
Ändere Für-Rede von GO-Anträgen und präzisiere Antworten auf Gegenreden

### DIFF
--- a/go.md
+++ b/go.md
@@ -105,9 +105,10 @@ Mitglieder und helfende Personen der ausrichtenden Fachschaft.
 1. *Geschäftsordnungsanträge* (GO-Anträge) werden durch das Heben
    beider Arme signalisiert und sind spätestens vor der nächsten Wortmeldung
    bzw. Abstimmung zu behandeln und abzustimmen.
-2. Es ist nur eine Für-Rede durch die antragstellende Person und eine Gegenrede
-   erlaubt, dabei ist eine inhaltliche einer formellen Gegenrede vorzuziehen.
+2. Es ist nur eine Rede für den Antrag durch die antragstellende Person und eine
+   Gegenrede erlaubt, dabei ist eine inhaltliche einer formellen Gegenrede vorzuziehen.
    Eine Diskussion von GO-Anträgen findet nicht statt.
+   Das Antwortrecht außerhalb der Redeliste besteht nicht.
 3. In der Abstimmung ist (bis auf unten angegebene Ausnahmen) eine Mehrheit von
    mehr Ja-Stimmen als der Summe von Nein-Stimmen und Enthaltungen erforderlich.
    Gibt es keine Gegenrede gilt der Antrag als angenommen.


### PR DESCRIPTION
Antrag 13/116

Antrag:
Ein „Für-Rede“ ist kein definiertes Wort. Der hintere Teil dient der Klarstellung, dass das Recht aus der Geschäftsordnung auf Antworten auf Rückfragen außerhalb der Redeliste gilt. Da die Redeliste das gewählte Werkzeug der Diskussion im Plenum darstellt, stellt eine Antwort auf eine Rückfrage innerhalb einer Gegenrede meiner Ansicht nach keinen Teil einer Diskussion dar. Dieses Recht wäre also üblicherweise zu gewähren, sollte allerdings für Geschäftsordnungsanträge nicht gelten. Fragen zum Verfahren selbst berührt dieser Punkt nicht. Diese würden ohnehin von der Redeleitung beantwortet werden.