### PR TITLE
Präzisiere dass Antragstellende auf Anträge Aufmerksam machen müssen

### DIFF
--- a/go.md
+++ b/go.md
@@ -92,6 +92,8 @@ Mitglieder und helfende Personen der ausrichtenden Fachschaft.
    oder kann eine Vertretung benennen und muss dies
    der Sitzungsleitung mitteilen.
    Die vertretende ist dann die neue antragstellende Person.
+   Die antragstellende Person hat selbst Sorge dafür zu tragen, dass die Redeleitung
+   des Antrags gewahr wird, z.B. durch einen Redebeitrag.
 8. Anträge, die bestehende Aussagen der ZaPF, insbesondere die Geschäftsordnung
    und die Satzung, ändern wollen, sollen ihre Änderung des bestehenden Textes
    *geeignet nachvollziehbar* machen.


### PR DESCRIPTION
Antrag 14/112

Antrag:
Dies dient der Unterstützung der Redeleitung und soll dabei helfen zu verhindern, dass Anträge übersehen werden.