### PR TITLE
Ändere dass Antragstellende sich um Antragstellung kümmern

### DIFF
--- a/go.md
+++ b/go.md
@@ -57,7 +57,8 @@ Mitglieder und helfende Personen der ausrichtenden Fachschaft.
    zwei Stunden vor Beginn des Plenums in Textform bei der die ZaPF
    ausrichtenden Fachschaft einzureichen.
    Dies gilt insbesondere für Texte, über die abgestimmt werden soll.
-   Die Arbeitskreise haben dafür zu sorgen, dass dies rechtzeitig geschieht.
+   Die antragstellenden Personen haben dafür zu sorgen, dass dies rechtzeitig
+   geschieht.
    Die Fristen für Anträge zur Änderung der Geschäftsordnung und des
    Verhaltenskodex der ZaPF werden in eigenen Absätzen geregelt.
 3. Plena können für spätere Plena einer ZaPF, z.B. das Anfangsplenum für alle


### PR DESCRIPTION
Antrag 140

Antrag:
Arbeitskreise sind bei der ZaPF nicht antragsberechtigt. Alle Anträge werden letztendlich durch teilnehmende Personen eingereicht, daher haben diese auch die Obliegenheit der pünktlichen Einreichung von Anträgen.